### PR TITLE
Update querySelector for id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Common selectors like class, id or attribute we can use `document.querySelector`
   $('#id');
 
   // Native
-  el.querySelectorAll('#id');
+  document.querySelector('#id');
   ```
 
 - [1.3](#1.3) <a name='1.3'></a> Query by attribute


### PR DESCRIPTION
There is always one id on the page always. So it is no need to use `querySelectorAll`, it is always use `querySelector` for selecting id