### PR TITLE
Move translations in the top of each readme

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -7,15 +7,28 @@ El desarrollo Frontend evoluciona día a día, y los navegadores modernos ya han
 
 ## Tabla de Contenidos
 
+1. [Traducción](#traducción)
 1. [Query Selector](#query-selector)
 1. [CSS & Estilo](#css--estilo)
 1. [Manipulación DOM](#manipulación-dom)
 1. [Ajax](#ajax)
 1. [Eventos](#eventos)
 1. [Utilidades](#utilidades)
-1. [Traducción](#traducción)
 1. [Soporte de Navegadores](#soporte-de-navegadores)
 
+## Traducción
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -613,19 +626,6 @@ Para un reemplazo completo con namespace y delegación, utilizar https://github.
   ```
 
 **[⬆ volver al inicio](#tabla-de-contenidos)**
-
-## Traducción
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Soporte de Navegadores
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -5,6 +5,7 @@ De nos jours, les environnements frontend évolus si rapidement que les navigate
 
 ## Sommaire
 
+1. [Traductions](#translation)
 1. [Sélecteur jQuery](#query-selector)
 1. [Style et CSS](#css--style)
 1. [Manipulation du DOM](#dom-manipulation)
@@ -14,8 +15,21 @@ De nos jours, les environnements frontend évolus si rapidement que les navigate
 1. [Promises](#promises)
 1. [Animation](#animation)
 1. [Alternatives](#alternatives)
-1. [Traduction](#translation)
 1. [Navigateurs compatibles](#browser-support)
+
+## Traductions
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Sélecteur jQuery
 

--- a/README-id.md
+++ b/README-id.md
@@ -5,14 +5,28 @@ Dewasa ini perkembangan environment frontend sangatlah pesat, dimana banyak brow
 
 ## Daftar Isi
 
+1. [Terjemahan](#translation)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css-style)
 1. [DOM Manipulation](#dom-manipulation)
 1. [Ajax](#ajax)
 1. [Events](#events)
 1. [Utilities](#utilities)
-1. [Translation](#translation)
 1. [Browser Support](#browser-yang-di-support)
+
+## Terjemahan
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -611,18 +625,6 @@ Untuk penggantian secara menyeluruh dengan namespace dan delegation, rujuk ke ht
   ```
 
 **[⬆ back to top](#daftar-isi)**
-
-## Terjemahan
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Browser yang di Support
 

--- a/README-it.md
+++ b/README-it.md
@@ -4,6 +4,7 @@ Il mondo del Frontend si evolve rapidamente oggigiorno, i browsers moderni hanno
 
 ## Tabella contenuti
 
+1. [Traduzioni](#traduzioni)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css--style)
 1. [Manipolazione DOM](#manipolazione-dom)
@@ -11,8 +12,21 @@ Il mondo del Frontend si evolve rapidamente oggigiorno, i browsers moderni hanno
 1. [Eventi](#eventi)
 1. [Utilities](#utilities)
 1. [Alternative](#alternative)
-1. [Traduzioni](#traduzioni)
 1. [Supporto Browsers](#supporto-browsers)
+
+## Traduzioni
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -627,19 +641,6 @@ Per una completa sostituzione con namespace e delegation, riferire a https://git
 
 * [Forse non hai bisogno di jQuery](http://youmightnotneedjquery.com/) - Esempi di come creare eventi comuni, elementi, ajax etc usando puramente javascript.
 * [npm-dom](http://github.com/npm-dom) e [webmodules](http://github.com/webmodules) - Organizzazione dove puoi trovare moduli per il DOM individuale su NPM
-
-## Traduzioni
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Italiano](./README-it.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Supporto Browsers
 

--- a/README-my.md
+++ b/README-my.md
@@ -4,14 +4,28 @@ Mutakhir ini perkembangan dalam persekitaran frontend berlaku begitu pesat sekal
 
 ## Isi Kandungan
 
+1. [Terjemahan](#terjemahan)
 1. [Pemilihan elemen](#pemilihan-elemen)
 1. [CSS & Penggayaan](#css-penggayaan)
 1. [Manipulasi DOM](#manipulasi-dom)
 1. [Ajax](#ajax)
 1. [Events](#events)
 1. [Utiliti](#utiliti)
-1. [Terjemahan](#terjemahan)
 1. [Browser Support](#browser-support)
+
+## Terjemahan
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Pemilihan Elemen
 
@@ -595,15 +609,6 @@ For a complete replacement with namespace and delegation, refer to https://githu
   ```
 
 **[⬆ back to top](#table-of-contents)**
-
-## Terjemahan
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [English](./README.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Sokongan Pelayar
 

--- a/README-ru.md
+++ b/README-ru.md
@@ -4,6 +4,7 @@
 
 ## Содержание
 
+1. [Переводы](#Переводы)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css--style)
 1. [Манипуляция DOM](#Манипуляции-dom)
@@ -11,8 +12,21 @@
 1. [События](#События)
 1. [Утилиты](#Утилиты)
 1. [Альтернативы](#Альтернативы)
-1. [Переводы](#Переводы)
 1. [Поддержка браузеров](#Поддержка-браузеров)
+
+## Переводы
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 Для часто используемых селекторов, таких как class, id или attribute мы можем использовать `document.querySelector` или `document.querySelectorAll` для замены. Разница такова:
@@ -626,19 +640,6 @@
 
 * [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - Примеры как исполняются частые события, элементы, ajax и тд с ванильным javascript.
 * [npm-dom](http://github.com/npm-dom) и [webmodules](http://github.com/webmodules) - Отдельные DOM модули можно найти на NPM
-
-## Переводы
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Поддержка браузеров
 

--- a/README-tr.md
+++ b/README-tr.md
@@ -4,6 +4,7 @@
 
 ## İçerik Tablosu
 
+1. [Çeviriler](#Çeviriler)
 1. [Sorgu seçiciler](#sorgu-seçiciler)
 1. [CSS & Stil](#css--stil)
 1. [DOM düzenleme](#dom-düzenleme)
@@ -11,8 +12,21 @@
 1. [Olaylar](#olaylar)
 1. [Araçlar](#araçlar)
 1. [Alternatifler](#alternatifler)
-1. [Çeviriler](#Çeviriler)
 1. [Tarayıcı desteği](#tarayıcı-desteği)
+
+## Çeviriler
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Sorgu seçiciler
 
@@ -641,19 +655,6 @@ Namespace ve Delegasyon ile tam olarak değiştirmek için, https://github.com/o
 
 * [jQuery'e İhtiyacınız Yok](http://youmightnotneedjquery.com/) - Yaygın olan olay, öğe ve ajax işlemlerinin yalın Javascript'teki karşılıklarına ait örnekler
 * [npm-dom](http://github.com/npm-dom) ve [webmodules](http://github.com/webmodules) - NPM için ayrı DOM modül organizasyonları
-
-## Çeviriler
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Tarayıcı Desteği
 

--- a/README-vi.md
+++ b/README-vi.md
@@ -13,6 +13,20 @@ Ngày nay, môi trường lập trình front-end phát triển rất nhanh chón
 1. [Ngôn ngữ khác](#ngôn-ngữ-khác)
 1. [Các trình duyệt hỗ trợ](#các-trình-duyệt-hỗ-trợ)
 
+## Ngôn ngữ khác
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
+
 ## Query Selector
 
 Đối với những selector phổ biến như class, id hoặc thuộc tính thì chúng ta có thể sử dụng `document.querySelector` hoặc `document.querySelectorAll` để thay thế cho jQuery selector. Sự khác biệt của hai hàm này là ở chỗ:
@@ -612,17 +626,6 @@ Thay thế bằng [fetch](https://github.com/camsong/fetch-ie8) và [fetch-jsonp
   ```
 
 **[⬆ Trở về đầu](#danh-mục)**
-
-## Ngôn ngữ khác
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Français](./README-fr.md)
 
 ## Các trình duyệt hỗ trợ
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -4,6 +4,7 @@
 
 ## 목차
 
+1. [번역](#번역)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css--style)
 1. [DOM 조작](#dom-조작)
@@ -13,8 +14,21 @@
 1. [Promises](#promises)
 1. [Animation](#animation)
 1. [대안방법](#대안방법)
-1. [번역](#번역)
 1. [브라우저 지원](#브라우저-지원)
+
+## 번역
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -1173,20 +1187,6 @@ Promise는 비동기적인 작업의 결과를 표현합니다. jQuery는 자체
 
 * [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - 일반 자바스크립트로 공통이벤트, 엘리먼트, ajax 등을 다루는 방법 예제.
 * [npm-dom](http://github.com/npm-dom) 과 [webmodules](http://github.com/webmodules) - 개별 DOM모듈을 NPM에서 찾을 수 있습니다.
-
-## 번역
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Italian](./README-it.md)
-* [Français](./README-fr.md)
 
 ## 브라우저 지원
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Frontend environments evolve rapidly nowadays, modern browsers have already impl
 
 ## Table of Contents
 
+1. [Translations](#translations)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css--style)
 1. [DOM Manipulation](#dom-manipulation)
@@ -13,8 +14,21 @@ Frontend environments evolve rapidly nowadays, modern browsers have already impl
 1. [Promises](#promises)
 1. [Animation](#animation)
 1. [Alternatives](#alternatives)
-1. [Translations](#translations)
 1. [Browser Support](#browser-support)
+
+## Translations
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -1203,20 +1217,6 @@ A promise represents the eventual result of an asynchronous operation. jQuery ha
 
 * [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - Examples of how to do common event, element, ajax etc with plain javascript.
 * [npm-dom](http://github.com/npm-dom) and [webmodules](http://github.com/webmodules) - Organizations you can find individual DOM modules on NPM
-
-## Translations
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Italian](./README-it.md)
-* [Français](./README-fr.md)
 
 ## Browser Support
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -7,6 +7,7 @@ Ambientes Frontend evoluem rapidamente nos dias de hoje, navegadores modernos j�
 
 ## Tabela de conteúdos
 
+1. [Translations](#translations)
 1. [Query Selector](#query-selector)
 1. [CSS & Estilo](#css--estilo)
 1. [Manipulação do DOM](#manipulação-do-dom)
@@ -14,6 +15,20 @@ Ambientes Frontend evoluem rapidamente nos dias de hoje, navegadores modernos j�
 1. [Eventos](#eventos)
 1. [Utilitários](#utilitários)
 1. [Suporte dos Navegadores](#suporte-dos-navegadores)
+
+## Translations
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,7 @@
 
 ## 目录
 
+1. [Translations](#translations)
 1. [Query Selector](#query-selector)
 1. [CSS & Style](#css--style)
 1. [DOM Manipulation](#dom-manipulation)
@@ -11,8 +12,21 @@
 1. [Events](#events)
 1. [Utilities](#utilities)
 1. [Alternatives](#alternatives)
-1. [Translations](#translations)
 1. [Browser Support](#browser-support)
+
+## Translations
+
+* [한국어](./README.ko-KR.md)
+* [简体中文](./README.zh-CN.md)
+* [Bahasa Melayu](./README-my.md)
+* [Bahasa Indonesia](./README-id.md)
+* [Português(PT-BR)](./README.pt-BR.md)
+* [Tiếng Việt Nam](./README-vi.md)
+* [Español](./README-es.md)
+* [Русский](./README-ru.md)
+* [Türkçe](./README-tr.md)
+* [Italiano](./README-it.md)
+* [Français](./README-fr.md)
 
 ## Query Selector
 
@@ -631,20 +645,6 @@
 
 * [你可能不需要 jQuery (You Might Not Need jQuery)](http://youmightnotneedjquery.com/) - 如何使用原生 JavaScript 实现通用事件，元素，ajax 等用法。
 * [npm-dom](http://github.com/npm-dom) 以及 [webmodules](http://github.com/webmodules) - 在 NPM 上提供独立 DOM 模块的组织
-
-## Translations
-
-* [한국어](./README.ko-KR.md)
-* [简体中文](./README.zh-CN.md)
-* [Bahasa Melayu](./README-my.md)
-* [Bahasa Indonesia](./README-id.md)
-* [Português(PT-BR)](./README.pt-BR.md)
-* [Tiếng Việt Nam](./README-vi.md)
-* [Español](./README-es.md)
-* [Русский](./README-ru.md)
-* [Türkçe](./README-tr.md)
-* [Italian](./README-it.md)
-* [Français](./READMEfr.md)
 
 ## Browser Support
 


### PR DESCRIPTION
Fix #82 

The `translations` section is now the first section in each translated README, `table of contents` of all files have also been updated in order to make `translations` appear as the first section.

List of available translations are now synchronized between each translations.

With love, from France ! :heart: 