### PR TITLE
arrow function use implicit return can't add ';' in the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In place of common selectors like class, id or attribute we can use `document.qu
 
     // Native
     Array.prototype.filter.call(el.parentNode.children, (child) =>
-      child !== el;
+      child !== el
     );
     ```
 


### PR DESCRIPTION
When i run then example, it throws an error "Uncaught SyntaxError: missing ) after argument list".
It just cause of the unnecessary ';'