### PR TITLE
Add npm replacement for $(document).ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,9 @@ For a complete replacement with namespace and delegation, refer to https://githu
   } else {
     document.addEventListener('DOMContentLoaded', eventHandler);
   }
+  
+  // npm
+  require('domready')(eventHandler)
   ```
 
 - [5.1](#5.1) <a name='5.1'></a> Bind an event with on


### PR DESCRIPTION
Non one-liner replacement for one-liner jquery is not such nice and isn't what people are actually looking for. I think giving examples using npm modules is more practical in that cases.