### PR TITLE
Added alternative approach to finding sibling elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ In place of common selectors like class, id or attribute we can use `document.qu
     [...el.parentNode.children].filter((child) =>
       child !== el
     );
+    // Native (alternative) - latest, Edge13+
+    Array.from(el.parentNode.children).filter((child) =>
+      child !== el
+    );
     // Native - IE10+
     Array.prototype.filter.call(el.parentNode.children, (child) =>
       child !== el

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ In place of common selectors like class, id or attribute we can use `document.qu
     // jQuery
     $el.siblings();
 
-    // Native
+    // Native - latest, Edge13+
+    [...el.parentNode.children].filter((child) =>
+      child !== el
+    );
+    // Native - IE10+
     Array.prototype.filter.call(el.parentNode.children, (child) =>
       child !== el
     );


### PR DESCRIPTION
While the IE10+ native solution for [finding siblings](https://github.com/oneuijs/You-Dont-Need-jQuery#1.5) of course works well, it also looks very discouraging for a developer trying to get away from jQuery. I've added a cleaner, ES6 friendly version using the [spread operator](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Spread_operator).

Additionally, we could also add another alternative approach using [`Array.from()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from) if the spread operator is too obscure for beginners:

```javascript
Array.from(el.parentNode.children).filter((child) =>
  child !== el
);
```