### PR TITLE
Fixed a small problem

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -369,7 +369,7 @@
     $el.height();
 
     // Native
-    // 与 jQuery 一致（一直为 content 区域的高度）
+    // 与 jQuery 一致（一致为 content 区域的高度）
     function getHeight(el) {
       const styles = this.getComputedStyle(el);
       const height = el.offsetHeight;


### PR DESCRIPTION
```
    // 与 jQuery 一致（一直为 content 区域的高度）
```
改为：
```
    // 与 jQuery 一致（一致为 content 区域的高度）
```
如果不改，`一直`这个词是为了表达什么？