### PR TITLE
Alternative approach to merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,9 @@ Most of utilities are found by native API. Others advanced functions could be ch
   function merge(...args) {
     return [].concat(...args)
   }
+
+  // ES6-way
+  array1 = [...array1, ...array2]
   ```
 
   + now


### PR DESCRIPTION
Added an easier, more succinct ES6 version of merging two arrays using the spread operator.

---
As for the comment `// But concat function doesn't remove duplicate items`, neither does the $.merge jQuery method.  If one was trying to remove duplicates I would suggest the following:

```JS
arr1 = [...new Set([...arr1, ...arr2])]
```

> That's a lot of spreading :dizzy_face: but it's pretty cool for being an (almost) native implementation.